### PR TITLE
Add dynamic scalling to canvas and areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import ImageMapper from 'react-image-mapper';
 |**width**|*number*|Image width|`Displayed width`|
 |**height**|*number*|Image height|`Displayed height`|
 |**active**|*bool*|Enable/Disable highlighting|`true`|
+|**imgWidth**|*number*|Original image width|`null`|
 
 |Props callbacks|Called on|signature|
 |---|---|---|
@@ -78,6 +79,26 @@ Its structure is similar to the HTML syntax of mapping:
 |**coords**|*array of number*|Coordinates delimiting the zone according to the specified shape: <ul><li>**rect**: `top-left-X`,`top-left-Y`,`bottom-right-X`,`bottom-right-Y`</li><li>**circle**: `center-X`,`center-Y`,`radius`</li><li>**poly**: Every point in the polygon path as `point-X`,`point-Y`,...</li></ul>|
 |**href**|*string*|Target link for a click in the zone (note that if you provide a onClick prop, `href` will be prevented)|
 
+## Dynamic scaling
+When a parent component updates the 'width' prop on `<ImageMapper>`, the area coordinates also have to be scaled. This can be accomplied by specifying both the new 'width' and a constant 'imgWidth'. 'imgWidth' is the width of the original image. `<ImageMapper>` will calculate the new coordinates for each area. For example: 
+```javascript
+/*assume that image is actually 1500px wide*/
+
+// this will be a 1:1 scale, areas will be 3x bigger than they should be
+<ImageMapper
+	width={500}
+/>
+// this will be the same 1:1 scale, same problem with areas being too big
+<ImageMapper
+	width={500}
+	imgWidth={500}
+/>
+// this will scale the areas to 1/3rd, they will now fit the 500px image on the screen
+<ImageMapper
+	width={500}
+	imgWidth={1500}
+/>
+```
 
 ## Development (`src`, `lib` and the build process)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Its structure is similar to the HTML syntax of mapping:
 |**href**|*string*|Target link for a click in the zone (note that if you provide a onClick prop, `href` will be prevented)|
 
 ## Dynamic scaling
-When a parent component updates the 'width' prop on `<ImageMapper>`, the area coordinates also have to be scaled. This can be accomplied by specifying both the new 'width' and a constant 'imgWidth'. 'imgWidth' is the width of the original image. `<ImageMapper>` will calculate the new coordinates for each area. For example: 
+When a parent component updates the *width* prop on `<ImageMapper>`, the area coordinates also have to be scaled. This can be accomplied by specifying both the new *width* and a constant *imgWidth*. *imgWidth* is the width of the original image. `<ImageMapper>` will calculate the new coordinates for each area. For example: 
 ```javascript
 /*assume that image is actually 1500px wide*/
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Its structure is similar to the HTML syntax of mapping:
 |**href**|*string*|Target link for a click in the zone (note that if you provide a onClick prop, `href` will be prevented)|
 
 ## Dynamic scaling
-When a parent component updates the *width* prop on `<ImageMapper>`, the area coordinates also have to be scaled. This can be accomplied by specifying both the new *width* and a constant *imgWidth*. *imgWidth* is the width of the original image. `<ImageMapper>` will calculate the new coordinates for each area. For example: 
+When a parent component updates the **width** prop on `<ImageMapper>`, the area coordinates also have to be scaled. This can be accomplied by specifying both the new **width** and a constant **imgWidth**. **imgWidth** is the width of the original image. `<ImageMapper>` will calculate the new coordinates for each area. For example: 
 ```javascript
 /*assume that image is actually 1500px wide*/
 

--- a/src/ImageMapper.js
+++ b/src/ImageMapper.js
@@ -14,6 +14,14 @@ export default class ImageMapper extends Component {
 		};
 	}
 
+	componentDidUpdate(prevProps, prevState) {
+		// only update chart if the data has changed
+		if (prevProps.width !== this.props.width) {
+			// re-draw canvas with the new width
+			this.initCanvas()
+		}
+	}
+
 	drawrect(coord) {
 		coord = coord.split(',');
 		let [left, top, right, bot] = coord;
@@ -81,8 +89,14 @@ export default class ImageMapper extends Component {
 	}
 
 	renderAreas() {
+		const { imgWidth, width } = this.props
+		// calculate scale based on current 'width' and the original 'imgWidth'
+		const scale = width && imgWidth && imgWidth > 0 ? width / imgWidth : 1
+		// method that is used to scale each area coordinates
+		const scaleCoords = coords => coords.map( coord => coord * scale )
+
 		return this.props.map.areas.map((area, index) => (
-			<area key={area._id || index} shape={area.shape} coords={area.coords.join(',')}
+			<area key={area._id || index} shape={area.shape} coords={scaleCoords(area.coords).join(',')}
 				  onMouseEnter={this.hoverOn.bind(this, area, index)}
 				  onMouseLeave={this.hoverOff.bind(this, area, index)}
 				  onClick={this.click.bind(this, area, index)} href={area.href} />
@@ -136,4 +150,5 @@ ImageMapper.propTypes = {
 	src: PropTypes.string.isRequired,
 	strokeColor: PropTypes.string,
 	width: PropTypes.number,
+	imgWidth: PropTypes.number,
 };


### PR DESCRIPTION
Fixes #10. Adds the ability to specify the original image width. This allows the component to scale areas and the canvas when parent component updates **width**. Added a section in the readme about it. 