### PR TITLE
Update ImageMapper.js

### DIFF
--- a/src/ImageMapper.js
+++ b/src/ImageMapper.js
@@ -39,7 +39,7 @@ export default class ImageMapper extends Component {
 		return !isEqual(this.props.map, this.state.map) || propChanged;
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		this.updateCacheMap();
 	}
 


### PR DESCRIPTION
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code from componentWillMount to componentDidMount (preferred in most cases) or the constructor.